### PR TITLE
Add multiarch, Dockerhub autobuild, and manifest creation.

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,4 +1,14 @@
-FROM lsiobase/alpine:3.10
+FROM alpine AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+#ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v4.0.0-balena/qemu-4.0.0-balena-arm.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+FROM lsiobase/alpine:arm32v7-3.10
+
+# Add QEMU
+COPY --from=builder qemu-arm-static /usr/bin
 
 ENV PUID=1000
 ENV PGID=1000

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,4 +1,14 @@
-FROM lsiobase/alpine:3.10
+FROM alpine AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+#ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v4.0.0-balena/qemu-4.0.0-balena-aarch64.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+FROM lsiobase/alpine:arm64v8-3.10
+
+# Add QEMU
+COPY --from=builder qemu-aarch64-static /usr/bin
 
 ENV PUID=1000
 ENV PGID=1000

--- a/Dockerfile.dev.arm32v7
+++ b/Dockerfile.dev.arm32v7
@@ -1,4 +1,14 @@
-FROM lsiobase/alpine:3.10
+FROM alpine AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+#ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v4.0.0-balena/qemu-4.0.0-balena-arm.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+FROM lsiobase/alpine:arm32v7-3.10
+
+# Add QEMU
+COPY --from=builder qemu-arm-static /usr/bin
 
 ENV PUID=1000
 ENV PGID=1000

--- a/Dockerfile.dev.arm64v8
+++ b/Dockerfile.dev.arm64v8
@@ -1,4 +1,15 @@
-FROM lsiobase/alpine:3.10
+FROM alpine AS builder
+
+# Download QEMU, see https://github.com/docker/hub-feedback/issues/1261
+#ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz
+ENV QEMU_URL https://github.com/balena-io/qemu/releases/download/v4.0.0-balena/qemu-4.0.0-balena-aarch64.tar.gz
+RUN apk add curl && curl -L ${QEMU_URL} | tar zxvf - -C . --strip-components 1
+
+
+ FROM lsiobase/alpine:arm64v8-3.10
+
+# Add QEMU
+COPY --from=builder qemu-aarch64-static /usr/bin
 
 ENV PUID=1000
 ENV PGID=1000

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ docker run -d --name Deezldr \
               -e PUID=1000 \
               -e PGID=1000 \
               -p 1730:1730 \
-              jstrader/deezloadermx
+              bocki/deezloaderrmx
 ```
 
 ### Example for Docker Compose:
@@ -24,7 +24,7 @@ $ docker run -d --name Deezldr \
 version: '3.3'
 services:
     deezloaderrmx:
-	    image: jstrader/deezloadermx
+	    image: bocki/deezloaderrmx
         container_name: Deezldr
         volumes:
             - /your/storage/path/:/downloads
@@ -64,11 +64,11 @@ There are only 2 tags right now.
 
 I am in no way affiliated with the DeezloaderRMX project (or any other Deezloader project for that matter), I just wanted the challenge to create my first Docker container.
 
-Dockerhub link for this container: https://hub.docker.com/r/jstrader/deezloadermx
+Dockerhub link for this container: https://hub.docker.com/r/bocki/deezloaderrmx
 
 Repo for Deezloader Remix: https://notabug.org/RemixDevs/DeezloaderRemix
 
-Issue Tracker for this Docker: https://github.com/tempestnano/deezloadermx-docker/issues
+Issue Tracker for this Docker: https://github.com/Bockiii/deezloadermx-docker/issues
 
 
 Feel free to open an issue that is Docker related, and not related to Deezloader development. Go to the Deezloader repository for that.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ docker run -d --name Deezldr \
               -e PUID=1000 \
               -e PGID=1000 \
               -p 1730:1730 \
-              bocki/deezloaderrmx
+              jstrader/deezloadermx
 ```
 
 ### Example for Docker Compose:
@@ -24,7 +24,7 @@ $ docker run -d --name Deezldr \
 version: '3.3'
 services:
     deezloaderrmx:
-	    image: bocki/deezloaderrmx
+	    image: jstrader/deezloadermx
         container_name: Deezldr
         volumes:
             - /your/storage/path/:/downloads
@@ -64,11 +64,11 @@ There are only 2 tags right now.
 
 I am in no way affiliated with the DeezloaderRMX project (or any other Deezloader project for that matter), I just wanted the challenge to create my first Docker container.
 
-Dockerhub link for this container: https://hub.docker.com/r/bocki/deezloaderrmx
+Dockerhub link for this container: https://hub.docker.com/r/jstrader/deezloadermx
 
 Repo for Deezloader Remix: https://notabug.org/RemixDevs/DeezloaderRemix
 
-Issue Tracker for this Docker: https://github.com/Bockiii/deezloadermx-docker/issues
+Issue Tracker for this Docker: https://github.com/tempestnano/deezloadermx-docker/issues
 
 
 Feel free to open an issue that is Docker related, and not related to Deezloader development. Go to the Deezloader repository for that.

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Use manifest-tool to create the manifest, given the experimental
+# "docker manifest" command isn't available yet on Docker Hub.
+
+#curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-arm64
+#chmod +x manifest-tool
+#docker manifest annotate jstrader/alpine-int-openvpn:latest jstrader/alpine-int-openvpn:arm32v7 --arch arm --variant v7
+#docker manifest annotate jstrader/alpine-int-openvpn:latest jstrader/alpine-int-openvpn:arm64v8 --arch arm --variant v8
+#docker manifest create jstrader/alpine-int-openvpn:latest --amend jstrader/alpine-int-openvpn:amd64 --amend jstrader/alpine-int-openvpn:arm32v7 --amend jstrader/alpine-int-openvpn:arm64v8
+#docker manifest inspect jstrader/alpine-int-openvpn:latest
+#./manifest-tool push from-spec multi-arch-manifest.yaml
+
+#!/bin/bash
+
+# Autobuild the Image on Docker Hub with advanced options
+# https://docs.docker.com/docker-hub/builds/advanced/
+
+# if the host is not equal to the building system architecture, set the image arch with manifest correctly on docker hub.
+
+set -e
+
+#IMAGE_OS=$(uname | tr '[:upper:]' '[:lower:]')
+IMAGE_OS="linux"
+HOST_ARCH=$(uname -m)
+HOST_ARCH_ALIAS=$([[ "${HOST_ARCH}" == "x86_64" ]] && echo "amd64" || echo "${HOST_ARCH}")
+BUILD_ARCH=$(echo "${DOCKERFILE_PATH}" | cut -d '.' -f 2)
+BUILD_ARCH=$([[ "${BUILD_ARCH}" == *\/* ]] && echo "${BUILD_ARCH}" | rev | cut -d '/' -f 1 | rev || echo "${BUILD_ARCH}")
+QEMU_USER_STATIC_ARCH=$([[ "${BUILD_ARCH}" == "armhf" ]] && echo "${BUILD_ARCH::-2}" || echo "${BUILD_ARCH}")
+PLATFORMS_ARCH=$([[ "${QEMU_USER_STATIC_ARCH}" == "arm" ]] && echo "${IMAGE_OS}/${QEMU_USER_STATIC_ARCH},${IMAGE_OS}/${QEMU_USER_STATIC_ARCH}64,${IMAGE_OS}/${HOST_ARCH_ALIAS}" || echo "${IMAGE_OS}/${QEMU_USER_STATIC_ARCH}")
+
+echo "PLATFORMS-ARCH: ${PLATFORMS_ARCH}"
+
+if [[ "${HOST_ARCH}" == "${QEMU_USER_STATIC_ARCH}"* || "${BUILD_ARCH}" == "Dockerfile"  ]]; then
+    echo "Building ${BUILD_ARCH} image natively; No manifest needed for current arch."
+    exit 0
+else
+    # Manifest
+
+    # docker manifest: https://docs.docker.com/engine/reference/commandline/manifest/
+    echo "docker manifest (not working with autobuild on docker hub)"
+    #docker manifest create "${IMAGE_NAME}" "${IMAGE_NAME}"
+    #docker manifest annotate "${IMAGE_NAME}" "${IMAGE_NAME}" --os "${IMAGE_OS}" --arch "${QEMU_USER_STATIC_ARCH}"
+    #docker manifest push "${IMAGE_NAME}"
+
+    # manifest-tool: https://github.com/estesp/manifest-tool
+    echo "manifest-tool"
+    # prerelease:
+    #MANIFEST_TOOL_VERSION=$(curl -s https://api.github.com/repos/estesp/manifest-tool/tags  | grep 'name.*v[0-9]' | head -n 1 | cut -d '"' -f 4)
+    # release:
+    MANIFEST_TOOL_VERSION=$(curl -s https://api.github.com/repos/estesp/manifest-tool/releases/latest | grep 'tag_name' | cut -d\" -f4)
+    curl -L https://github.com/estesp/manifest-tool/releases/download/$MANIFEST_TOOL_VERSION/manifest-tool-$IMAGE_OS-$HOST_ARCH_ALIAS -o manifest-tool
+    chmod +x manifest-tool
+    #./manifest-tool push from-args --platforms ${PLATFORMS_ARCH} --template ${IMAGE_NAME} --target ${IMAGE_NAME}
+    ./manifest-tool push from-spec manifest.yaml
+    ./manifest-tool push from-spec manifest.dev.yaml
+fi

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-# Use manifest-tool to create the manifest, given the experimental
-# "docker manifest" command isn't available yet on Docker Hub.
-
-#curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-arm64
-#chmod +x manifest-tool
-#docker manifest annotate jstrader/alpine-int-openvpn:latest jstrader/alpine-int-openvpn:arm32v7 --arch arm --variant v7
-#docker manifest annotate jstrader/alpine-int-openvpn:latest jstrader/alpine-int-openvpn:arm64v8 --arch arm --variant v8
-#docker manifest create jstrader/alpine-int-openvpn:latest --amend jstrader/alpine-int-openvpn:amd64 --amend jstrader/alpine-int-openvpn:arm32v7 --amend jstrader/alpine-int-openvpn:arm64v8
-#docker manifest inspect jstrader/alpine-int-openvpn:latest
-#./manifest-tool push from-spec multi-arch-manifest.yaml
-
-#!/bin/bash
-
 # Autobuild the Image on Docker Hub with advanced options
 # https://docs.docker.com/docker-hub/builds/advanced/
 

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Register qemu-*-static for all supported processors except the 
+# current one, but also remove all registered binfmt_misc before
+docker run --rm --privileged multiarch/qemu-user-static:register --reset

--- a/manifest.dev.yaml
+++ b/manifest.dev.yaml
@@ -1,15 +1,15 @@
-image: jstrader/deezloadermx:dev
+image: bocki/deezloaderrmx:dev
 manifests:
-  - image: jstrader/deezloadermx:dev.amd64
+  - image: bocki/deezloaderrmx:dev.amd64
     platform:
       architecture: amd64
       os: linux
-  - image: jstrader/deezloadermx:dev.arm32v7
+  - image: bocki/deezloaderrmx:dev.arm32v7
     platform:
       architecture: arm
       os: linux
       variant: v7
-  - image: jstrader/deezloadermx:dev.arm64v8
+  - image: bocki/deezloaderrmx:dev.arm64v8
     platform:
       architecture: arm64
       os: linux

--- a/manifest.dev.yaml
+++ b/manifest.dev.yaml
@@ -1,0 +1,16 @@
+image: jstrader/deezloadermx:dev
+manifests:
+  - image: jstrader/deezloadermx:dev.amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: jstrader/deezloadermx:dev.arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7
+  - image: jstrader/deezloadermx:dev.arm64v8
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,16 @@
+image: jstrader/deezloadermx:latest
+manifests:
+  - image: jstrader/deezloadermx:amd64
+    platform:
+      architecture: amd64
+      os: linux
+  - image: jstrader/deezloadermx:arm32v7
+    platform:
+      architecture: arm
+      os: linux
+      variant: v7
+  - image: jstrader/deezloadermx:arm64v8
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,15 +1,15 @@
-image: jstrader/deezloadermx:latest
+image: bocki/deezloaderrmx:latest
 manifests:
-  - image: jstrader/deezloadermx:amd64
+  - image: bocki/deezloaderrmx:amd64
     platform:
       architecture: amd64
       os: linux
-  - image: jstrader/deezloadermx:arm32v7
+  - image: bocki/deezloaderrmx:arm32v7
     platform:
       architecture: arm
       os: linux
       variant: v7
-  - image: jstrader/deezloadermx:arm64v8
+  - image: bocki/deezloaderrmx:arm64v8
     platform:
       architecture: arm64
       os: linux


### PR DESCRIPTION
I finally worked out the kinks, and I can confirm it works as expected on amd64 and arm32v7 architectures. I assume arm64v8 will work as well, as it builds and is practically identical. It is setup, so Dockerhub can autobuild and push all architectures to the latest and dev tags.

The post_push manifest creation should fail for the first builds, as I think the tags (amd64 arm32v7 and arm64v8) for each architecture need to be created before the manifest operation can complete successfully. 